### PR TITLE
disable #echo "</pre>";

### DIFF
--- a/functions/functions.php
+++ b/functions/functions.php
@@ -62,7 +62,7 @@ function showAll(){
 	foreach ($multisite_pairs as $name => $url) {
 		$out .= "<option value='" . esc_url($url) . "'>" . trim($name) . "</option>";
 	}
-	echo "</pre>";
+	#echo "</pre>";
 	return $out;
 }
 


### PR DESCRIPTION
#echo "</pre>"; was causing problems in DIVI when the menu got inserted into the top (secondary) menu.