### PR TITLE
Changed the max limit of pages listed to 1000

### DIFF
--- a/functions/functions.php
+++ b/functions/functions.php
@@ -42,6 +42,7 @@ function showAll() {
 		'deleted' => 0,
 		'spam'    => 0,
 		'orderby' => array( 'path' ),
+		'number'  => 1000,
 	);
 
 	apply_filters('dms_sites_arguments', $sites_arguments);


### PR DESCRIPTION
Thanks to Gideon who found the solution for the fixed limit in the plugin to 100
https://developer.wordpress.org/reference/functions/get_sites/
get_sites (int) Maximum number of sites to retrieve. Default 100

Co-Authored-By: gideonso <gideonso@users.noreply.github.com>